### PR TITLE
Fix false munmap error

### DIFF
--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -369,7 +369,7 @@ static void *map_file(FD fd, map_t *mapping)
 static void unmap_file(void *data, map_t size)
 {
   if (!data) return;
-  if (!munmap(data, size)) {
+  if (munmap(data, size) != 0) {
 	  perror("munmap");
   }
 }


### PR DESCRIPTION
According to https://linux.die.net/man/2/munmap:
```
On success, munmap() returns 0, on failure -1, and errno is set (probably to EINVAL).
```

The condition in unmap_file function is inverted, munmap on success returns 0, so now it will always call perror. I've fixed it by comparing to 0, so hopefully will be ok now.