### PR TITLE
Fix mapping offset for wide dtz tables.

### DIFF
--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -1556,7 +1556,7 @@ static bool init_table(struct BaseEntry *be, const char *str, int type)
       if (flags[t] & 2) {
         if (!(flags[t] & 16)) {
           for (int i = 0; i < 4; i++) {
-            mapIdx[t][i] = (uint16_t)(data + 1 - (uint8_t *)map);
+            mapIdx[t][i] = ((uint16_t *)data + 1 - (uint16_t *)map);
             data += 1 + data[0];
           }
         } else {

--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -1556,13 +1556,13 @@ static bool init_table(struct BaseEntry *be, const char *str, int type)
       if (flags[t] & 2) {
         if (!(flags[t] & 16)) {
           for (int i = 0; i < 4; i++) {
-            mapIdx[t][i] = ((uint16_t *)data + 1 - (uint16_t *)map);
+            mapIdx[t][i] = (uint16_t)(data + 1 - (uint8_t *)map);
             data += 1 + data[0];
           }
         } else {
           data += (uintptr_t)data & 0x01;
           for (int i = 0; i < 4; i++) {
-            mapIdx[t][i] = (uint16_t)(data + 1 - (uint8_t *)map);
+            mapIdx[t][i] = (uint16_t)((uint16_t*)data + 1 - (uint16_t *)map);
             data += 2 + 2 * read_le_u16(data);
           }
         }


### PR DESCRIPTION
I'm pretty sure this fixes a bug in Fathom when probing tablebases that use "wide" dtz tables which were introduced here: https://github.com/syzygy1/tb/commit/213823d3f6b340405703f724898fd509e0cc516e
I came on this bug when I followed a bug report in Stockfish which was (different from this one!) about wrong scores in positions with very big DTZ values. I noticed that my engine even crashed because it didn't support the wide dtz extension at all. And while implementing it looking at Fathom (well, looking at Ethereal's implementation of it called Pyrrhic) I discovered that Fathom/Pyrrhic doesn't crash but still gives wrong values when reading the DTZ tables with the "wide dtz" extension.

How to repruduce the problem (following the SF issue in https://github.com/official-stockfish/Stockfish/pull/4187)
1. Get the 7-men tablebase files KRBNvKQN.rtbw, KRBNvKQN.rtbz
2. Enable Syzygy TB but disable Syzygy50Move rule
3. Probe the position qn4N1/6R1/3K4/8/B2k4/8/8/8 w - - 0 1

You will (most probably) notice that you won't get the expected DTZ 1034.
At least this is what I saw, when I did it the Fathom way in my engine: Wrong values that were identical to the values in Ethereal==Pyrrhic==Fathom.
After applying the patch of this pull request in my engine the values are correct, so I guess this patch will also work in Fathom.
