### PR TITLE
Add top level Makefile for compiling a shared object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MKDIR_P = mkdir -p
 RM      = rm
 INSTALL = install
 
-CC      = gcc
+CC     ?= gcc
 CFLAGS  = -std=gnu99 -O2 -Wall -Wshadow -Isrc
 LDFLAGS = $(CFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+MKDIR_P = mkdir -p
+RM      = rm
+INSTALL = install
+
+CC      = gcc
+CFLAGS  = -std=gnu99 -O2 -Wall -Wshadow -Isrc
+LDFLAGS = $(CFLAGS)
+
+PREFIX  = /usr/local
+LIBDIR  = $(PREFIX)/lib64
+INCDIR  = $(PREFIX)/include
+
+libfathom.so: obj/tbprobe.o
+	$(CC) $(LDFLAGS) -shared $^ -o $@
+
+obj/tbprobe.o: src/tbprobe.c src/tbchess.c src/stdendian.h src/tbprobe.h
+	@$(MKDIR_P) obj
+	$(CC) $(CFLAGS) -fPIC -c $< -o $@
+
+clean:
+	$(RM) -f libfathom.so
+	$(RM) -rf obj
+
+install: libfathom.so
+	$(MKDIR_P) $(DESTDIR)$(LIBDIR)
+	$(INSTALL) -m 0644 libfathom.so $(DESTDIR)$(LIBDIR)
+	$(INSTALL) -m 0644 src/{stdendian,tbconfig,tbprobe}.h $(DESTDIR)$(INCDIR)
+
+uninstall:
+	$(RM) -f $(DESTDIR)$(LIBDIR)/libfathom.so
+	$(RM) -f $(DESTDIR)$(INCDIR)/{stdendian,tbconfig,tbprobe}.h
+
+.PHONY: clean install uninstall

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ are:
 Fathom is compilable under either C99 or C++ and supports a variety of
 platforms, including at least Windows, Linux, and MacOS.
 
+Building the library
+--------------------
+It is possible to build and install Fathom as a shared library on Unix-like
+systems. Simple run the commands
+
+    make
+    make install
+
+in the top level directory.
+
 Tool
 ----
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ platforms, including at least Windows, Linux, and MacOS.
 Building the library
 --------------------
 It is possible to build and install Fathom as a shared library on Unix-like
-systems. Simple run the commands
+systems. Simply run the commands
 
     make
     make install


### PR DESCRIPTION
Added a top level Makefile that compiles and installs a shared object and headers for unix-like systems. This would be very helpful to have so that Fathom can be used as any other library on for example Linux. This makes Fathom even easier to integrate into chess software.