### PR TITLE
Remove note about tb_probe_root being thread unsafe (?)

### DIFF
--- a/src/tbprobe.h
+++ b/src/tbprobe.h
@@ -268,8 +268,6 @@ static inline unsigned tb_probe_wdl(
  * - DTZ tablebases can suggest unnatural moves, especially for losing
  *   positions.  Engines may prefer to traditional search combined with WDL
  *   move filtering using the alternative results array.
- * - This function is NOT thread safe.  For engines this function should only
- *   be called once at the root per search.
  */
 static inline unsigned tb_probe_root(
     uint64_t _white,


### PR DESCRIPTION
Since I'm not able to open issues nor contact you in any other way I will open this pull request. 

Why is tb_probe_root marked as thread unsafe? I do not understand every detail of the code, but it seems to me that every function at some point calls probe_table (which is thread safe as long as Fathom is built appropriately.) None of the other functions that tb_probe_root calls (that I could find) were thread unsafe.

Of course this does not mean you should call the function during search since it is slow. However the thread safety is still useful for me because I'm doing some data generation on multiple independent threads.