### PR TITLE
tb_init verifies if already initialized by checking if pieceEntry is

### DIFF
--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -1019,7 +1019,9 @@ void tb_free(void)
 {
   tb_init("");
   free(pieceEntry);
+  pieceEntry = NULL;
   free(pawnEntry);
+  pawnEntry = NULL;
 }
 
 static const int8_t OffDiag[] = {


### PR DESCRIPTION
tb_init verifies if already initialized by checking if pieceEntry is NULL. tb_free DID free that memory but did not set the variable to NULL hence confusing the init part.