### PR TITLE
C++ Fixes for Engine Integration

### DIFF
--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -22,7 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#ifdef TB_ASSERT
+#define assert(x) TB_ASSERT(x)
+#else
 #include <assert.h>
+#endif
+
 #ifdef __cplusplus
 #include <atomic>
 #else
@@ -32,11 +37,15 @@ SOFTWARE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef __cplusplus
 #ifdef TB_NO_STDBOOL
-#typedef uint8 bool
+typedef uint8 bool
 #else
 #include <stdbool.h>
 #endif
+#endif
+
 #include "tbprobe.h"
 
 #define TB_PIECES 7

--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -704,8 +704,8 @@ static bool test_tb(const char *str, const char *suffix)
     size_t size = file_size(fd);
     close_tb(fd);
     if ((size & 63) != 16) {
-      fprintf(stderr, "Incomplete tablebase file %s.%s\n", str, suffix);
-      printf("info string Incomplete tablebase file %s.%s\n", str, suffix);
+      fprintf(stderr, "Incomplete tablebase file %s%s\n", str, suffix);
+      printf("info string Incomplete tablebase file %s%s\n", str, suffix);
       fd = FD_ERR;
     }
   }


### PR DESCRIPTION
Fix crashes related to incorrect initialization when compiling with C++20 (and later) compilers. 
Allow assert customization.
Fix double dot in filenames in incomplete table base error message.